### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target
+.settings
+.classpath
+.project
+.idea
+*.iml
+.DS_Store


### PR DESCRIPTION
A .gitignore file tells git to ignore files that we shouldn't check into our source control on GitHub. This includes things like the compiled program (the target/ directory) and files that are just about your local file system or IDE. This way, they won't get added to your commits or show up in `git status`, and we won't have to worry about accidentally checking them in.

Git documentation: https://git-scm.com/docs/gitignore