### PR TITLE
Modification to the user-page.html so that the message form displays on every user page

### DIFF
--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -30,21 +30,23 @@ function setPageTitle() {
 }
 
 /**
- * Shows the message form if the user is logged in and viewing their own page.
+ * Shows the message form if the user is logged in and viewing every user page.
  */
-function showMessageFormIfViewingSelf() {
+function showMessageFormIfLoggedIn() {
   fetch('/login-status')
       .then((response) => {
         return response.json();
       })
       .then((loginStatus) => {
-        if (loginStatus.isLoggedIn &&
-            loginStatus.username == parameterUsername) {
+        if (loginStatus.isLoggedIn) {
           const messageForm = document.getElementById('message-form');
+        messageForm.action = '/messages? recipient=' + parameterUsername;
           messageForm.classList.remove('hidden');
         }
       });
-}
+
+    }
+
 
 /** Fetches messages and add them to the page. */
 function fetchMessages() {

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -95,6 +95,6 @@ function buildMessageDiv(message) {
 /** Fetches data and populates the UI of the page. */
 function buildUI() {
   setPageTitle();
-  showMessageFormIfViewingSelf();
+  showMessageFormIfLoggedIn()
   fetchMessages();
 }

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -40,7 +40,7 @@ function showMessageFormIfLoggedIn() {
       .then((loginStatus) => {
         if (loginStatus.isLoggedIn) {
           const messageForm = document.getElementById('message-form');
-        messageForm.action = '/messages? recipient=' + parameterUsername;
+        messageForm.action = '/messages?recipient=' + parameterUsername;
           messageForm.classList.remove('hidden');
         }
       });


### PR DESCRIPTION
Modified the user-page.html, specifically the `showMessageFormIfViewingSelf()` function of the user-page-loader.js  file to enable its logic to show the form as long as the user is logged in, even if they aren't viewing their own page. With this change, the message form displays on every user page, not just on a user's own page. But please note that this doesn't actually change the behavior of the server