### PR TITLE
changed jsoup to allow basic HTML tags in messages instead of none

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,7 +76,7 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String text = Jsoup.clean(request.getParameter("text"), Whitelist.basic());
     String recipient = request.getParameter("recipient");
 
     Message message = new Message(user, text, recipient);

--- a/src/main/webapp/js/build-messages-helper.js
+++ b/src/main/webapp/js/build-messages-helper.js
@@ -16,7 +16,7 @@ function buildMessageDiv(message){
 
  const bodyDiv = document.createElement('div');
  bodyDiv.classList.add('message-body');
- bodyDiv.appendChild(document.createTextNode(message.text));
+ bodyDiv.innerHTML = message.text; 
 
  const messageDiv = document.createElement('div');
  messageDiv.classList.add("message-div");


### PR DESCRIPTION
Look up jsoup whitelist basic to see whats allowed I can also quickly change it to the simpleText one as well 

Update: HTML is now rendering 
<img width="665" alt="screen shot 2019-03-07 at 9 17 41 pm" src="https://user-images.githubusercontent.com/37354543/54003025-b4d20d80-411e-11e9-8f5d-585ac02294e5.png">
