### PR TITLE
added delete button to messages on user page

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -22,6 +22,8 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,8 +45,20 @@ public class Datastore {
     messageEntity.setProperty("text", message.getText());
     messageEntity.setProperty("timestamp", message.getTimestamp());
     messageEntity.setProperty("recipient", message.getRecipient());
+    messageEntity.setProperty("ID", message.getId().toString());
 
     datastore.put(messageEntity);
+  }
+
+  /** Deletes the Message in Datastore. */
+  public void deleteMessage(String ID) {
+
+    //queries for the message based on its UUID
+    Filter propertyFilter = new FilterPredicate("ID", FilterOperator.EQUAL, ID);
+    Query q = new Query("Message").setFilter(propertyFilter);
+    PreparedQuery pq = datastore.prepare(q);
+    Entity storedMessage = pq.asSingleEntity();
+    datastore.delete(storedMessage.getKey());
   }
 
   /**

--- a/src/main/java/com/google/codeu/servlets/DeleteMessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/DeleteMessageServlet.java
@@ -1,0 +1,41 @@
+package com.google.codeu.servlets;
+
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.codeu.data.Datastore;
+import com.google.codeu.data.Message;
+
+import java.io.IOException;
+
+@WebServlet("/delete")
+public class DeleteMessageServlet extends HttpServlet{
+
+  private Datastore datastore;
+
+  @Override
+  public void init() {
+   datastore = new Datastore();
+  }
+
+ @Override
+ public void doGet(HttpServletRequest request, HttpServletResponse response)
+   throws IOException {
+
+     UserService userService = UserServiceFactory.getUserService();
+     String user = userService.getCurrentUser().getEmail();
+
+     String messageID = request.getParameter("message-id");
+     datastore.deleteMessage(messageID);
+
+     System.out.print("before redirect");
+     response.sendRedirect("/user-page.html?user=" + user);
+     System.out.print("after redirect");
+
+ }
+}

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -63,6 +63,18 @@ function fetchMessages() {
         }
         messages.forEach((message) => {
           const messageDiv = buildMessageDiv(message);
+
+          const deleteButton = document.createElement('button');
+          deleteButton.value = message.id;
+          deleteButton.name = "message-id";
+          deleteButton.innerText = "Delete";
+
+          const deleteForm = document.createElement('form');
+          deleteForm.action = "/delete";
+          deleteForm.method = "GET";
+          deleteForm.appendChild(deleteButton);
+
+          messageDiv.firstChild.appendChild(deleteForm);
           messagesContainer.appendChild(messageDiv);
         });
       });


### PR DESCRIPTION
Functionality: deletes message from datastore and redirects back to the user page

NOTE: this only works on newly created messages because I added the ID property to them. After this code is merged and pushed to app engine we should delete the existing datastore manually because delete wont work on them

<img width="635" alt="Screen Shot 2019-03-21 at 12 26 30 PM" src="https://user-images.githubusercontent.com/37354543/54768355-61a79280-4bd5-11e9-9b59-5b1074e0c615.png">
<img width="630" alt="Screen Shot 2019-03-21 at 12 26 40 PM" src="https://user-images.githubusercontent.com/37354543/54768358-63715600-4bd5-11e9-907f-71626251b061.png">
